### PR TITLE
test: cover fallow CRAP hotspots and gate bun test in lint-staged

### DIFF
--- a/app/components/form/get-fetcher-status.test.ts
+++ b/app/components/form/get-fetcher-status.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getFetcherStatus,
+  getNavigationFormStatus,
+} from "./get-fetcher-status";
+
+describe("getFetcherStatus", () => {
+  it("returns pending while fetcher is busy", () => {
+    expect(getFetcherStatus("submitting")).toBe("pending");
+    expect(getFetcherStatus("loading", { ok: true })).toBe("pending");
+  });
+
+  it("returns pending when transition is pending even if idle", () => {
+    expect(
+      getFetcherStatus("idle", { ok: true }, { isTransitionPending: true })
+    ).toBe("pending");
+  });
+
+  it("maps idle + ok discriminant to success / error / idle", () => {
+    expect(getFetcherStatus("idle", { ok: true })).toBe("success");
+    expect(getFetcherStatus("idle", { ok: false })).toBe("error");
+    expect(getFetcherStatus("idle")).toBe("idle");
+    expect(getFetcherStatus("idle", null)).toBe("idle");
+    expect(getFetcherStatus("idle", {})).toBe("idle");
+  });
+});
+
+describe("getNavigationFormStatus", () => {
+  it("returns pending for this form's submitting / loading navigation", () => {
+    expect(getNavigationFormStatus("submitting")).toBe("pending");
+    expect(getNavigationFormStatus("loading", { ok: true })).toBe("pending");
+    expect(
+      getNavigationFormStatus(
+        "submitting",
+        { ok: false },
+        {
+          isFormNavigation: true,
+        }
+      )
+    ).toBe("pending");
+  });
+
+  it("ignores unrelated navigation when isFormNavigation is false", () => {
+    expect(
+      getNavigationFormStatus(
+        "loading",
+        { ok: true },
+        {
+          isFormNavigation: false,
+        }
+      )
+    ).toBe("success");
+
+    expect(
+      getNavigationFormStatus(
+        "submitting",
+        { ok: false },
+        {
+          isFormNavigation: false,
+        }
+      )
+    ).toBe("error");
+
+    expect(
+      getNavigationFormStatus("loading", undefined, {
+        isFormNavigation: false,
+      })
+    ).toBe("idle");
+  });
+
+  it("maps idle + ok discriminant to success / error / idle", () => {
+    expect(getNavigationFormStatus("idle", { ok: true })).toBe("success");
+    expect(getNavigationFormStatus("idle", { ok: false })).toBe("error");
+    expect(getNavigationFormStatus("idle")).toBe("idle");
+    expect(getNavigationFormStatus("idle", null)).toBe("idle");
+    expect(getNavigationFormStatus("idle", {})).toBe("idle");
+  });
+
+  it("defaults isFormBusy from navigationState when option omitted", () => {
+    // submitting → isFormBusy true → pending
+    expect(getNavigationFormStatus("submitting", { ok: true })).toBe("pending");
+    // idle → isFormBusy false → read actionData
+    expect(getNavigationFormStatus("idle", { ok: true })).toBe("success");
+  });
+});

--- a/app/components/form/read-action-form-data.test.ts
+++ b/app/components/form/read-action-form-data.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import { readActionFormData } from "./read-action-form-data";
+
+type ErrorFields = "email" | "password" | "name";
+type EchoFields = "email" | "name";
+
+const defaults = {
+  email: "guest@example.com",
+  name: "",
+} as const;
+
+describe("readActionFormData", () => {
+  it("returns defaults and empty error fields when data is undefined", () => {
+    const result = readActionFormData<ErrorFields, EchoFields, typeof defaults>(
+      undefined,
+      { defaults }
+    );
+
+    expect(result).toEqual({
+      fieldErrors: undefined,
+      formData: { email: "guest@example.com", name: "" },
+      formError: undefined,
+      ok: undefined,
+    });
+  });
+
+  it("keeps defaults on success and surfaces ok: true", () => {
+    const result = readActionFormData<ErrorFields, EchoFields, typeof defaults>(
+      { ok: true },
+      { defaults }
+    );
+
+    expect(result).toEqual({
+      fieldErrors: undefined,
+      formData: { email: "guest@example.com", name: "" },
+      formError: undefined,
+      ok: true,
+    });
+  });
+
+  it("merges echoed failure formData over defaults", () => {
+    const result = readActionFormData<ErrorFields, EchoFields, typeof defaults>(
+      {
+        fieldErrors: { email: "Invalid email" },
+        formData: { email: "bad@", name: "Ada" },
+        formError: "Fix the highlighted fields",
+        ok: false,
+      },
+      { defaults }
+    );
+
+    expect(result).toEqual({
+      fieldErrors: { email: "Invalid email" },
+      formData: { email: "bad@", name: "Ada" },
+      formError: "Fix the highlighted fields",
+      ok: false,
+    });
+  });
+
+  it("keeps default when echoed key is missing", () => {
+    const result = readActionFormData<ErrorFields, EchoFields, typeof defaults>(
+      {
+        formData: { email: "echoed@example.com" },
+        ok: false,
+      },
+      { defaults }
+    );
+
+    expect(result.formData).toEqual({
+      email: "echoed@example.com",
+      name: "",
+    });
+  });
+
+  it("skips undefined echo values so defaults stay", () => {
+    const result = readActionFormData<ErrorFields, EchoFields, typeof defaults>(
+      {
+        formData: { email: undefined, name: "Kept" },
+        ok: false,
+      },
+      { defaults }
+    );
+
+    expect(result.formData).toEqual({
+      email: "guest@example.com",
+      name: "Kept",
+    });
+  });
+
+  it("returns empty formData object when no defaults and no echo", () => {
+    const result = readActionFormData<
+      ErrorFields,
+      EchoFields,
+      Record<string, never>
+    >({ ok: false });
+
+    expect(result).toEqual({
+      fieldErrors: undefined,
+      formData: {},
+      formError: undefined,
+      ok: false,
+    });
+  });
+
+  it("does not treat success payload formData as echo", () => {
+    const result = readActionFormData<ErrorFields, EchoFields, typeof defaults>(
+      { ok: true },
+      { defaults }
+    );
+
+    expect(result.formData).toEqual({
+      email: "guest@example.com",
+      name: "",
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/app/features/vans/hooks/use-display-host-vans.test.ts
+++ b/app/features/vans/hooks/use-display-host-vans.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "bun:test";
+import type { VanModel } from "~/db/client.server";
+import { VanState, VanType } from "~/db/enums";
+import type { HostVanListItem, PendingVan } from "~/features/vans/types";
+import type { UUIDv7 } from "~/types/ids.server";
+import { useDisplayHostVans } from "./use-display-host-vans";
+
+const HOST_ID = "01900000-0000-7000-8000-000000000001" as UUIDv7;
+
+const IDS = {
+  created: "01900000-0000-7000-8000-000000000010" as UUIDv7,
+  other: "01900000-0000-7000-8000-000000000020" as UUIDv7,
+  v1: "01900000-0000-7000-8000-000000000030" as UUIDv7,
+  v2: "01900000-0000-7000-8000-000000000040" as UUIDv7,
+  v3: "01900000-0000-7000-8000-000000000050" as UUIDv7,
+} as const;
+
+function makeVan(
+  overrides: Partial<VanModel> & Pick<VanModel, "id" | "slug">
+): VanModel {
+  return {
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    description: "A fine van",
+    discount: 0,
+    hostId: HOST_ID,
+    imageUrl: "https://example.com/van.jpg",
+    isRented: false,
+    name: "Test Van",
+    price: 80,
+    state: VanState.AVAILABLE,
+    type: VanType.SIMPLE,
+    ...overrides,
+  };
+}
+
+function makePending(
+  overrides: Partial<PendingVan> & Pick<PendingVan, "clientKey" | "slug">
+): PendingVan {
+  return {
+    description: "Pending van",
+    discount: 0,
+    id: `pending_${overrides.clientKey}`,
+    imageUrl: "",
+    name: "Pending",
+    price: 80,
+    status: "pending",
+    type: VanType.SIMPLE,
+    ...overrides,
+  };
+}
+
+const created = makeVan({ id: IDS.created, slug: "desert-dream" });
+const other = makeVan({ id: IDS.other, name: "Other", slug: "other-van" });
+
+describe("useDisplayHostVans", () => {
+  it("returns optimistic items when fetcher has not created a van yet", () => {
+    const optimisticItems: HostVanListItem[] = [
+      makePending({ clientKey: "ck_1", slug: "desert-dream" }),
+      other,
+    ];
+
+    expect(
+      useDisplayHostVans({
+        fetcherData: undefined,
+        fetcherState: "idle",
+        limit: 10,
+        optimisticItems,
+      })
+    ).toEqual(optimisticItems);
+
+    expect(
+      useDisplayHostVans({
+        fetcherData: { formError: "Nope", ok: false },
+        fetcherState: "idle",
+        limit: 10,
+        optimisticItems,
+      })
+    ).toEqual(optimisticItems);
+
+    expect(
+      useDisplayHostVans({
+        fetcherData: { ok: true, van: created },
+        fetcherState: "submitting",
+        limit: 10,
+        optimisticItems,
+      })
+    ).toEqual(optimisticItems);
+  });
+
+  it("swaps pending matched by clientKey for the created van", () => {
+    const pending = makePending({
+      clientKey: "ck_match",
+      slug: "temp-slug",
+    });
+
+    const result = useDisplayHostVans({
+      fetcherData: {
+        clientKey: "ck_match",
+        ok: true,
+        van: created,
+      },
+      fetcherState: "idle",
+      limit: 10,
+      optimisticItems: [pending, other],
+    });
+
+    expect(result).toEqual([created, other]);
+  });
+
+  it("swaps pending matched by slug when clientKey differs", () => {
+    const pending = makePending({
+      clientKey: "ck_other",
+      slug: "desert-dream",
+    });
+
+    const result = useDisplayHostVans({
+      fetcherData: {
+        clientKey: "ck_new",
+        ok: true,
+        van: created,
+      },
+      fetcherState: "idle",
+      limit: 10,
+      optimisticItems: [pending, other],
+    });
+
+    expect(result).toEqual([created, other]);
+  });
+
+  it("does not prepend when created van already in list", () => {
+    const result = useDisplayHostVans({
+      fetcherData: {
+        clientKey: "ck_1",
+        ok: true,
+        van: created,
+      },
+      fetcherState: "idle",
+      limit: 10,
+      optimisticItems: [other, created],
+    });
+
+    expect(result).toEqual([other, created]);
+  });
+
+  it("strips unmatched pending vans once a create succeeds", () => {
+    const strayPending = makePending({
+      clientKey: "ck_stray",
+      slug: "unrelated",
+    });
+
+    const result = useDisplayHostVans({
+      fetcherData: {
+        clientKey: "ck_match",
+        ok: true,
+        van: created,
+      },
+      fetcherState: "idle",
+      limit: 10,
+      optimisticItems: [strayPending, other],
+    });
+
+    expect(result).toEqual([created, other]);
+  });
+
+  it("respects limit when prepending created van", () => {
+    const vans = [
+      makeVan({ id: IDS.v1, slug: "a" }),
+      makeVan({ id: IDS.v2, slug: "b" }),
+      makeVan({ id: IDS.v3, slug: "c" }),
+    ];
+
+    const result = useDisplayHostVans({
+      fetcherData: { ok: true, van: created },
+      fetcherState: "idle",
+      limit: 2,
+      optimisticItems: vans,
+    });
+
+    expect(result).toEqual([created, vans[0]]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("respects limit when created already present", () => {
+    const vans = [
+      created,
+      makeVan({ id: IDS.v1, slug: "a" }),
+      makeVan({ id: IDS.v2, slug: "b" }),
+    ];
+
+    const result = useDisplayHostVans({
+      fetcherData: { ok: true, van: created },
+      fetcherState: "idle",
+      limit: 2,
+      optimisticItems: vans,
+    });
+
+    expect(result).toEqual([created, vans[1]]);
+  });
+});

--- a/app/utils/to-action-result.server.test.ts
+++ b/app/utils/to-action-result.server.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import { err, ok } from "~/utils/service-result.server";
+import { toActionResultOrThrow } from "~/utils/to-action-result.server";
+
+interface FailurePayload {
+  fieldErrors?: Partial<Record<string, string>>;
+  formData?: Partial<Record<string, string>>;
+  formError: string;
+  ok: false;
+}
+
+interface DataResult<TData = FailurePayload> {
+  data: TData;
+  init: { status: number };
+  type: "DataWithResponseInit";
+}
+
+function asDataResult<TData = FailurePayload>(
+  value: unknown
+): DataResult<TData> {
+  return value as DataResult<TData>;
+}
+
+describe("toActionResultOrThrow", () => {
+  it("returns null on success so caller can continue", () => {
+    expect(toActionResultOrThrow(ok({ id: "van_1" }))).toBeNull();
+  });
+
+  it("throws notFound (404) for not_found", () => {
+    expect(() =>
+      toActionResultOrThrow(err({ kind: "not_found", message: "Van gone" }))
+    ).toThrow();
+
+    try {
+      toActionResultOrThrow(err({ kind: "not_found", message: "Van gone" }));
+    } catch (thrown) {
+      const result = asDataResult<string>(thrown);
+      expect(result.type).toBe("DataWithResponseInit");
+      expect(result.init.status).toBe(404);
+      expect(result.data).toBe("Van gone");
+    }
+  });
+
+  it.each([
+    "forbidden",
+    "unavailable",
+    "insufficient_funds",
+    "invalid_input",
+  ] as const)("maps %s → badRequest (400)", (kind) => {
+    const result = asDataResult(
+      toActionResultOrThrow(err({ kind, message: `${kind} boom` }))
+    );
+
+    expect(result.type).toBe("DataWithResponseInit");
+    expect(result.init.status).toBe(400);
+    expect(result.data).toEqual({
+      formError: `${kind} boom`,
+      ok: false,
+    });
+  });
+
+  it("maps conflict → conflict (409)", () => {
+    const result = asDataResult(
+      toActionResultOrThrow(
+        err({ kind: "conflict", message: "Already rented" })
+      )
+    );
+
+    expect(result.init.status).toBe(409);
+    expect(result.data).toEqual({
+      formError: "Already rented",
+      ok: false,
+    });
+  });
+
+  it("maps internal → internalError (500)", () => {
+    const result = asDataResult(
+      toActionResultOrThrow(err({ kind: "internal", message: "DB melted" }))
+    );
+
+    expect(result.init.status).toBe(500);
+    expect(result.data).toEqual({
+      formError: "DB melted",
+      ok: false,
+    });
+  });
+
+  it("forwards fieldErrors and formData extras onto client failures", () => {
+    const extras = {
+      fieldErrors: { amount: "Too low" },
+      formData: { amount: "1" },
+    };
+
+    const result = asDataResult(
+      toActionResultOrThrow(
+        err({ kind: "insufficient_funds", message: "Need more coin" }),
+        extras
+      )
+    );
+
+    expect(result.init.status).toBe(400);
+    expect(result.data).toEqual({
+      fieldErrors: { amount: "Too low" },
+      formData: { amount: "1" },
+      formError: "Need more coin",
+      ok: false,
+    });
+  });
+
+  it("forwards extras onto conflict and internal too", () => {
+    const extras = {
+      fieldErrors: { slug: "Taken" },
+      formData: { slug: "desert-dream" },
+    };
+
+    const conflictResult = asDataResult(
+      toActionResultOrThrow(
+        err({ kind: "conflict", message: "Slug taken" }),
+        extras
+      )
+    );
+    expect(conflictResult.init.status).toBe(409);
+    expect(conflictResult.data.fieldErrors).toEqual({ slug: "Taken" });
+    expect(conflictResult.data.formData).toEqual({ slug: "desert-dream" });
+
+    const internalResult = asDataResult(
+      toActionResultOrThrow(err({ kind: "internal", message: "Nope" }), extras)
+    );
+    expect(internalResult.init.status).toBe(500);
+    expect(internalResult.data.fieldErrors).toEqual({ slug: "Taken" });
+  });
+});

--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -4,5 +4,6 @@ export default {
   "*.{js,jsx,ts,tsx,json,jsonc,css,scss,md,mdx}": () => "bun fix",
   "**/*.{js,jsx,ts,tsx}": () =>
     "bunx react-doctor --staged --blocking warning --no-score -y",
-  "**/*.{ts,tsx}": () => "bun typecheck",
+  // Callbacks so lint-staged does not append filenames (tsc/bun test need whole project).
+  "**/*.{ts,tsx}": [() => "bun typecheck", () => "bun test"],
 } satisfies Configuration;


### PR DESCRIPTION
## Summary
🧪 Covered fallow CRAP hotspots: `readActionFormData`, `toActionResultOrThrow`, `useDisplayHostVans`, form status helpers
🔧 Ran `bun test` once per commit via lint-staged callbacks

Closes #85

## Test plan
- [ ] `bun test` — all new suites green
- [ ] `bun typecheck` — no errors on new test files
- [ ] Stage a `.ts` file and run `bunx lint-staged` — typecheck then full test suite run once (no per-file `bun test` args)
- [ ] Re-run `fallow health --complexity` — confirm the four hotspot functions still identified; coverage path is via tests, not fallow config


Made with [Cursor](https://cursor.com)