### PR TITLE
refactor: chart stats mapper, orange skeleton, deferred host streaming

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -240,12 +240,13 @@
 
 /* ─── CUSTOM UTILITIES ───────────────────────────────────────────────────── */
 @utility bg-skeleton {
-  background-color: var(--color-gray-300);
+  --_sk-color: var(--skeleton-color, var(--color-gray-300));
+  background-color: var(--_sk-color);
   background-image: linear-gradient(
     90deg,
-    var(--color-gray-300) 25%,
-    var(--color-gray-200) 50%,
-    var(--color-gray-300) 75%
+    var(--_sk-color) 25%,
+    var(--skeleton-highlight, var(--color-gray-200)) 50%,
+    var(--_sk-color) 75%
   );
   background-size: 200% 100%;
   animation: --shimmer 2s infinite linear;

--- a/app/features/host/components/bar-chart/bar-chart-skeleton.tsx
+++ b/app/features/host/components/bar-chart/bar-chart-skeleton.tsx
@@ -1,7 +1,7 @@
 const BarChartSkeleton = () => (
   <div className="v-host-chart h-full w-full">
     {/* Chart area with 6 bars using CSS pseudo-random heights via custom properties */}
-    <div className="flex h-(--chart-content-height) items-end justify-between gap-2 px-4 [&>div:nth-child(1)]:[--bar-index:1] [&>div:nth-child(2)]:[--bar-index:2] [&>div:nth-child(3)]:[--bar-index:3] [&>div:nth-child(4)]:[--bar-index:4] [&>div:nth-child(5)]:[--bar-index:5] [&>div:nth-child(6)]:[--bar-index:6]">
+    <div className="flex h-(--chart-content-height) items-end justify-between gap-2 px-4 [--skeleton-color:var(--color-orange-400)] [--skeleton-highlight:var(--color-orange-200)] [&>div:nth-child(1)]:[--bar-index:1] [&>div:nth-child(2)]:[--bar-index:2] [&>div:nth-child(3)]:[--bar-index:3] [&>div:nth-child(4)]:[--bar-index:4] [&>div:nth-child(5)]:[--bar-index:5] [&>div:nth-child(6)]:[--bar-index:6]">
       <div className="bar-height w-1/8 rounded-t bg-skeleton" />
       <div className="bar-height w-1/8 rounded-t bg-skeleton" />
       <div className="bar-height w-1/8 rounded-t bg-skeleton" />

--- a/app/features/host/dal/transaction.server.ts
+++ b/app/features/host/dal/transaction.server.ts
@@ -77,17 +77,12 @@ export async function getHostIncomeStats(db: AppDb, userId: UUIDv7) {
       count: count(),
       firstAt: min(transaction.createdAt),
       lastAt: max(transaction.createdAt),
-      total: sum(transaction.amount),
+      total: sum(transaction.amount).mapWith(Number),
     })
     .from(transaction)
     .where(hostIncomeWhere(userId));
 
-  return {
-    count: result?.count ?? 0,
-    firstAt: result?.firstAt ?? null,
-    lastAt: result?.lastAt ?? null,
-    total: Number(result?.total ?? 0),
-  };
+  return result;
 }
 
 /**
@@ -105,12 +100,7 @@ export async function getUserTransferStats(db: AppDb, userId: UUIDv7) {
     .from(transaction)
     .where(userTransactionsWhere(userId));
 
-  return {
-    count: result?.count ?? 0,
-    firstAt: result?.firstAt ?? null,
-    lastAt: result?.lastAt ?? null,
-    total: Number(result?.total ?? 0),
-  };
+  return result;
 }
 
 /**

--- a/app/features/host/services/dashboard.server.ts
+++ b/app/features/host/services/dashboard.server.ts
@@ -4,6 +4,7 @@ import {
   getAccountSummary,
   getHostIncomeStats,
 } from "~/features/host/dal/transaction.server";
+import { toTransactionAggStats } from "~/features/host/utils/resolve-chart-context.server";
 import { getHostVans } from "~/features/vans/dal/host-van.server";
 import type { UUIDv7 } from "~/types/ids.server";
 import { elapsedDaysFromRange } from "~/utils/get-elapsed-time.server";
@@ -23,20 +24,19 @@ export async function loadHostDashboard(db: AppDb, userId: UUIDv7) {
   const [
     { data: avgRating },
     { data: transactionSummary },
-    { data: incomeStats },
+    { data: rawIncomeStats },
   ] = await Promise.all([
     tryCatch(() => getAverageReviewRating(db, userId)),
     tryCatch(() => getAccountSummary(db, userId)),
     tryCatch(() => getHostIncomeStats(db, userId)),
   ]);
 
+  const { firstAt, lastAt, total } = toTransactionAggStats(rawIncomeStats);
+
   return {
     avgRating: avgRating ?? 0,
-    elapsedDays: elapsedDaysFromRange(
-      incomeStats?.firstAt,
-      incomeStats?.lastAt
-    ),
-    sumIncome: incomeStats?.total ?? 0,
+    elapsedDays: elapsedDaysFromRange(firstAt, lastAt),
+    sumIncome: total,
     transactionSummary: transactionSummary ?? 0,
     vansPromise,
   };

--- a/app/features/host/services/income.server.ts
+++ b/app/features/host/services/income.server.ts
@@ -4,10 +4,13 @@ import {
   getHostIncomeStats,
   getHostTransactionsPaginated,
 } from "~/features/host/dal/transaction.server";
-import { resolveChartContext } from "~/features/host/utils/resolve-chart-context.server";
+import {
+  resolveChartContext,
+  toTransactionAggStats,
+} from "~/features/host/utils/resolve-chart-context.server";
 import type {
   BasePaginationParams,
-  SortOption,
+  SortObject,
 } from "~/features/pagination/types";
 import { toPagination } from "~/features/pagination/utils/to-pagination.server";
 import type { Prettify } from "~/types";
@@ -15,9 +18,7 @@ import type { UUIDv7 } from "~/types/ids.server";
 import { tryCatch } from "~/utils/try-catch.server";
 
 export type HostPaginatedPageParams = Prettify<
-  BasePaginationParams & {
-    sort: SortOption;
-  }
+  BasePaginationParams & SortObject
 >;
 
 export async function loadIncomePage(
@@ -41,12 +42,14 @@ export async function loadIncomePage(
     })
   );
 
-  const { data: stats } = await tryCatch(() => getHostIncomeStats(db, userId));
+  const { data: rawStats } = await tryCatch(() =>
+    getHostIncomeStats(db, userId)
+  );
+
+  const { total, ...stats } = toTransactionAggStats(rawStats);
 
   const { count, elapsedDays, granularity } = resolveChartContext({
-    count: stats?.count ?? 0,
-    firstAt: stats?.firstAt,
-    lastAt: stats?.lastAt,
+    ...stats,
   });
 
   const { data: chartData } = await tryCatch(() =>
@@ -58,7 +61,7 @@ export async function loadIncomePage(
     elapsedDays,
     granularity,
     pagePromise,
-    sumIncome: stats?.total ?? 0,
+    sumIncome: total,
     txnCount: count,
   };
 }

--- a/app/features/host/services/rental.server.ts
+++ b/app/features/host/services/rental.server.ts
@@ -101,19 +101,15 @@ export async function loadReturnRentalContext(
   return { money, rent };
 }
 
+interface CompleteReturnRentalParams {
+  money: number;
+  rent: HostRentedVan;
+  rentId: UUIDv7;
+  userId: UUIDv7;
+}
 export async function completeReturnRental(
   db: AppDb,
-  {
-    rentId,
-    userId,
-    rent,
-    money,
-  }: {
-    rentId: UUIDv7;
-    userId: UUIDv7;
-    rent: HostRentedVan;
-    money: number;
-  }
+  { rentId, userId, rent, money }: CompleteReturnRentalParams
 ) {
   const amountToPay = getCost(rent.rentedAt, new Date(), rent.van);
 

--- a/app/features/host/services/transfers.server.ts
+++ b/app/features/host/services/transfers.server.ts
@@ -5,7 +5,10 @@ import {
   getUserTransferStats,
 } from "~/features/host/dal/transaction.server";
 import type { HostPaginatedPageParams } from "~/features/host/services/income.server";
-import { resolveChartContext } from "~/features/host/utils/resolve-chart-context.server";
+import {
+  resolveChartContext,
+  toTransactionAggStats,
+} from "~/features/host/utils/resolve-chart-context.server";
 import { toPagination } from "~/features/pagination/utils/to-pagination.server";
 import type { UUIDv7 } from "~/types/ids.server";
 import { tryCatch } from "~/utils/try-catch.server";
@@ -31,14 +34,14 @@ export async function loadTransfersPage(
     })
   );
 
-  const { data: stats } = await tryCatch(() =>
+  const { data: rawStats } = await tryCatch(() =>
     getUserTransferStats(db, userId)
   );
 
+  const { total, ...stats } = toTransactionAggStats(rawStats);
+
   const { count, elapsedDays, granularity } = resolveChartContext({
-    count: stats?.count ?? 0,
-    firstAt: stats?.firstAt,
-    lastAt: stats?.lastAt,
+    ...stats,
   });
 
   const { data: chartData } = await tryCatch(() =>
@@ -50,7 +53,7 @@ export async function loadTransfersPage(
     elapsedDays,
     granularity,
     pagePromise,
-    sumAmount: stats?.total ?? 0,
+    sumAmount: total,
     txnCount: count,
   };
 }

--- a/app/features/host/utils/resolve-chart-context.server.test.ts
+++ b/app/features/host/utils/resolve-chart-context.server.test.ts
@@ -1,5 +1,60 @@
 import { describe, expect, it } from "bun:test";
-import { resolveChartContext } from "./resolve-chart-context.server";
+import {
+  resolveChartContext,
+  toTransactionAggStats,
+} from "./resolve-chart-context.server";
+
+describe("toTransactionAggStats", () => {
+  it("returns zeros and nulls when row missing", () => {
+    expect(toTransactionAggStats(undefined)).toEqual({
+      count: 0,
+      firstAt: null,
+      lastAt: null,
+      total: 0,
+    });
+    expect(toTransactionAggStats(null)).toEqual({
+      count: 0,
+      firstAt: null,
+      lastAt: null,
+      total: 0,
+    });
+  });
+
+  it("passes through a complete row", () => {
+    const firstAt = new Date("2024-01-01T00:00:00Z");
+    const lastAt = new Date("2024-06-01T00:00:00Z");
+
+    expect(
+      toTransactionAggStats({
+        count: 12,
+        firstAt,
+        lastAt,
+        total: 450.5,
+      })
+    ).toEqual({
+      count: 12,
+      firstAt,
+      lastAt,
+      total: 450.5,
+    });
+  });
+
+  it("coerces nullish total via Number", () => {
+    expect(
+      toTransactionAggStats({
+        count: 3,
+        firstAt: null,
+        lastAt: null,
+        total: null as unknown as number,
+      })
+    ).toEqual({
+      count: 3,
+      firstAt: null,
+      lastAt: null,
+      total: 0,
+    });
+  });
+});
 
 describe("resolveChartContext", () => {
   it("derives count, elapsedDays, and granularity from stats", () => {

--- a/app/features/host/utils/resolve-chart-context.server.ts
+++ b/app/features/host/utils/resolve-chart-context.server.ts
@@ -1,11 +1,28 @@
 import { pickChartGranularity } from "~/features/host/utils/pick-chart-granularity.server";
-import type { Maybe } from "~/types";
+import type { Maybe, Prettify } from "~/types";
 import { elapsedDaysFromRange } from "~/utils/get-elapsed-time.server";
 
-export interface TransactionSpanStats {
+interface TransactionSpanStats {
   count: number;
   firstAt: Maybe<Date>;
   lastAt: Maybe<Date>;
+}
+
+type RawTransactionAggStats = Prettify<
+  Partial<TransactionSpanStats> & { total: Maybe<number> }
+>;
+type TransactionAggStats = Prettify<TransactionSpanStats & { total: number }>;
+
+/** Normalize optional aggregate row with nullish defaults. */
+export function toTransactionAggStats(
+  row: Maybe<RawTransactionAggStats>
+): TransactionAggStats {
+  return {
+    count: row?.count ?? 0,
+    firstAt: row?.firstAt ?? null,
+    lastAt: row?.lastAt ?? null,
+    total: Number(row?.total ?? 0),
+  };
 }
 
 /**

--- a/app/features/pagination/types.ts
+++ b/app/features/pagination/types.ts
@@ -45,8 +45,12 @@ export type BasePaginationParams = Prettify<
 export type ToPaginationParams<T> = Prettify<Items<T> & BasePaginationParams>;
 
 export type PaginationParams = Prettify<
-  BasePaginationParams & {
-    sort?: SortOption;
-    userId: UUIDv7;
-  }
+  BasePaginationParams &
+    Partial<SortObject> & {
+      userId: UUIDv7;
+    }
 >;
+
+export interface SortObject {
+  sort: SortOption;
+}

--- a/app/features/pagination/utils/resolve-sorted-cursor.server.ts
+++ b/app/features/pagination/utils/resolve-sorted-cursor.server.ts
@@ -1,6 +1,6 @@
 import type {
   BasePaginationParams,
-  SortOption,
+  SortObject,
 } from "~/features/pagination/types";
 import {
   createGenericOrderBy,
@@ -12,9 +12,7 @@ import { getCursorMetadata } from "./get-cursor-metadata.server";
 import { reverseSortOption } from "./reverse-sort-order";
 
 type ResolveSortedCursorParams = Prettify<
-  BasePaginationParams & {
-    sort?: SortOption;
-  }
+  BasePaginationParams & Partial<SortObject>
 >;
 
 interface ResolvedSortedCursor {

--- a/app/features/vans/components/van-header.tsx
+++ b/app/features/vans/components/van-header.tsx
@@ -1,7 +1,12 @@
 import type { ComponentPropsWithoutRef } from "react";
 
 const VanHeader = ({ children }: ComponentPropsWithoutRef<"h2">) => (
-  <h2 className="font-bold text-3xl">{children}</h2>
+  <h2
+    className="font-bold text-3xl"
+    style={{ viewTransitionName: "van-header" }}
+  >
+    {children}
+  </h2>
 );
 
 export { VanHeader };

--- a/bun.lock
+++ b/bun.lock
@@ -29,12 +29,12 @@
       "devDependencies": {
         "@babel/core": "^8.0.1",
         "@biomejs/biome": "2.5.3",
-        "@cloudflare/vite-plugin": "1.44.0",
+        "@cloudflare/vite-plugin": "1.45.0",
         "@cloudflare/workers-types": "^5.20260716.1",
         "@fontsource-variable/inter": "^5.2.8",
         "@react-router/dev": "8.2.0",
         "@rolldown/plugin-babel": "^0.2.3",
-        "@tailwindcss/vite": "^4.3.2",
+        "@tailwindcss/vite": "^4.3.3",
         "@types/babel__core": "^7.20.5",
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.1",
@@ -48,11 +48,11 @@
         "lint-staged": "^17.0.8",
         "react-doctor": "^0.7.8",
         "rollup-plugin-visualizer": "^7.0.1",
-        "tailwindcss": "^4.3.2",
+        "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
         "ultracite": "7.9.4",
         "vite": "8.1.5",
-        "wrangler": "^4.110.0",
+        "wrangler": "^4.111.0",
       },
     },
   },
@@ -167,17 +167,17 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.44.0", "", { "dependencies": { "@cloudflare/unenv-preset": "2.16.1", "miniflare": "4.20260708.1", "unenv": "2.0.0-rc.24", "wrangler": "4.110.0", "ws": "8.21.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0 || ^8.0.0" }, "bin": { "cf-vite": "bin/cf-vite" } }, "sha512-8wGGunqRcs34o4GRq0Rurp7GZg30xtLJeRGUU81a49r9zQRjlp3xIlsWr3nFlSCso4eE3cjZfiKC/2y116M4TQ=="],
+    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.45.0", "", { "dependencies": { "@cloudflare/unenv-preset": "2.16.1", "miniflare": "4.20260710.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260710.1", "wrangler": "4.111.0", "ws": "8.21.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0 || ^8.0.0" }, "bin": { "cf-vite": "bin/cf-vite" } }, "sha512-TXK2HuhKF7Q/hMBj3Eih6241pEgQzbrVoNLIpT2lRJHipHaCGoQjN8Q7O8fjWSUEnJkkFn8lQt1QyzJ21DoRlQ=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260708.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260710.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-OqJl2eWF5+y9jarMm3YqqCTUe7Hd4ihogX5jyRU8iaAgOVyDr/Bk6aXpPCVUi1/MHzO93a18R/TmSTtzmB0sQw=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260708.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260710.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MYBqWgUblO+VlGvO73zYsH3hB9tdRj+yLyt5IHDFWryipb2l1efmNiWtAOkIhSRfypqLYGFrfpaDm2Hg00XVKw=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260708.1", "", { "os": "linux", "cpu": "x64" }, "sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260710.1", "", { "os": "linux", "cpu": "x64" }, "sha512-lVWUgqI8qrkqvaCBGElu1kdaUFdAvaS2RD8K4qkCFP9hI3f5TCXumEs5qWSeZkvKum0+X/uJZ5hBFWsYI5SmoQ=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260708.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260710.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-kDwDPItBjAI4JL0df9Fma2N+Qggbm77IB/DnroAkEGQ79fpR80sYMyuB/ZQKyjEk9f48Ocq7HCCLq59qVSyNqA=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260710.1", "", { "os": "win32", "cpu": "x64" }, "sha512-GcLHy1oN1dfK6g1Z7UDV9f5xMGyTfPwcjWQ0sfWKH31IsoEVCRapnj3IC0PoIrDbnoo6irGPP0CwVs3WzdTajw=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260716.1", "", {}, "sha512-LqQPmGAvdpQxzZGAMlDI6fnCsTlr8nRQibWsREaERqD0PucwFl25aXpUskSob70uSY2n6K1sp6Te9xkmzSFgaw=="],
 
@@ -625,35 +625,35 @@
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.2", "@tailwindcss/oxide-darwin-arm64": "4.3.2", "@tailwindcss/oxide-darwin-x64": "4.3.2", "@tailwindcss/oxide-freebsd-x64": "4.3.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2", "@tailwindcss/oxide-linux-arm64-musl": "4.3.2", "@tailwindcss/oxide-linux-x64-gnu": "4.3.2", "@tailwindcss/oxide-linux-x64-musl": "4.3.2", "@tailwindcss/oxide-wasm32-wasi": "4.3.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2", "@tailwindcss/oxide-win32-x64-msvc": "4.3.2" } }, "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.2", "", { "os": "android", "cpu": "arm64" }, "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.2", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
 
-    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.2", "", { "dependencies": { "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "tailwindcss": "4.3.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA=="],
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -971,7 +971,7 @@
 
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+    "enhanced-resolve": ["enhanced-resolve@5.24.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -1207,7 +1207,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "miniflare": ["miniflare@4.20260708.1", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260708.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA=="],
+    "miniflare": ["miniflare@4.20260710.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260710.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-x1LLRkU6o1p7hiKrB0TRnL0MJn6xFOT+/vrlEQINz5cRDKLP8ru4hBqWTIvXAetzr1acKAnmAaG84pQ4W/K14g=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -1403,7 +1403,7 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
-    "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -1481,9 +1481,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20260708.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260708.1", "@cloudflare/workerd-darwin-arm64": "1.20260708.1", "@cloudflare/workerd-linux-64": "1.20260708.1", "@cloudflare/workerd-linux-arm64": "1.20260708.1", "@cloudflare/workerd-windows-64": "1.20260708.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w=="],
+    "workerd": ["workerd@1.20260710.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260710.1", "@cloudflare/workerd-darwin-arm64": "1.20260710.1", "@cloudflare/workerd-linux-64": "1.20260710.1", "@cloudflare/workerd-linux-arm64": "1.20260710.1", "@cloudflare/workerd-windows-64": "1.20260710.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-U2sBPPrb9U97sBKnnMN6Kv8p65903P35nwMkPE9vSH/bRuRqkZ3a1EjUw3jV28RhiyXpkLF77Evzw8XimFxyTw=="],
 
-    "wrangler": ["wrangler@4.110.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260708.1", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260708.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260708.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg=="],
+    "wrangler": ["wrangler@4.111.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260710.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260710.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260710.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ=="],
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
@@ -1589,15 +1589,15 @@
 
     "@reduxjs/toolkit/reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1808,8 +1808,6 @@
     "@react-router/dev/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
     "@react-router/dev/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/babel__core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "@better-auth/drizzle-adapter": "1.7.0-rc.1",
     "@forge42/seo-tools": "^1.4.5",
     "@varlock/bitwarden-plugin": "^2.0.0",
-    "@varlock/cloudflare-integration": "^1.3.0",
     "arktype": "^2.2.3",
     "better-auth": "1.7.0-rc.1",
     "cnfast": "^0.0.8",
@@ -22,14 +21,15 @@
     "varlock": "1.11.0"
   },
   "devDependencies": {
+    "@varlock/cloudflare-integration": "^1.3.0",
     "@babel/core": "^8.0.1",
     "@biomejs/biome": "2.5.3",
-    "@cloudflare/vite-plugin": "1.44.0",
+    "@cloudflare/vite-plugin": "1.45.0",
     "@cloudflare/workers-types": "^5.20260716.1",
     "@fontsource-variable/inter": "^5.2.8",
     "@react-router/dev": "8.2.0",
     "@rolldown/plugin-babel": "^0.2.3",
-    "@tailwindcss/vite": "^4.3.2",
+    "@tailwindcss/vite": "^4.3.3",
     "@types/babel__core": "^7.20.5",
     "@types/bun": "^1.3.14",
     "@types/node": "^26.1.1",
@@ -43,11 +43,11 @@
     "lint-staged": "^17.0.8",
     "react-doctor": "^0.7.8",
     "rollup-plugin-visualizer": "^7.0.1",
-    "tailwindcss": "^4.3.2",
+    "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "ultracite": "7.9.4",
     "vite": "8.1.5",
-    "wrangler": "^4.110.0"
+    "wrangler": "^4.111.0"
   },
   "name": "van-life",
   "scripts": {


### PR DESCRIPTION
## Summary
♻️ Extract `toTransactionAggStats` for raw→domain chart stats (Closes #99, Closes #100)
🎯 Wire income/transfers/dashboard through one normalize path after tryCatch
🎨 Restore orange chart skeleton via CSS custom props (Closes #101)
⚡ Deferred host list loaders via DeferredAwait/DeferredPaginated + skeletons
📊 Server SQL chart aggregations / granularity helpers
🧊 Centralized cache headers + Workers Cache; private no-store for host/auth
🐛 Sign WITHDRAW only for transfer charts/stats and wallet balance
📦 Bump wrangler, Tailwind, Cloudflare Vite plugin, Vite/Varlock

## Test plan
- [ ] `bun test app/features/host/utils/resolve-chart-context.server.test.ts`
- [ ] Host income + transfers pages: stats/chart load; empty host soft-fails to zeros
- [ ] Host dashboard: sumIncome / elapsedDays match income page after mapper
- [ ] Lazy Recharts load: bar chart skeleton shows orange shimmer (not gray)
- [ ] Host lists still stream via DeferredPaginated skeletons
- [ ] `bun run typecheck` / `bun x ultracite check`


Made with [Cursor](https://cursor.com)